### PR TITLE
Add meta title to url description

### DIFF
--- a/source/includes/_transfers.md
+++ b/source/includes/_transfers.md
@@ -18,6 +18,7 @@ transfer = client.create_transfer(name: 'My very first transfer!', description: 
   builder.add_file(name: 'cat-picture.jpg', io: StringIO.new('cat-picture'))
   builder.add_file(name: 'README.txt', io: File.open('/path/to/local/readme.txt', 'rb'))
   builder.add_file_at(path: __FILE__)
+  builder.add_web_url(url: "https://www.the.url.you.want.to.share.com", title: "title of the url"))
 end
 ```
 

--- a/source/includes/_transfers.md
+++ b/source/includes/_transfers.md
@@ -152,6 +152,7 @@ name | type | required | description
 ---- | ---- | -------- | -----------
 `content_identifier` |	String | Yes | _Must_ be "web_content".
 `url` | String | Yes | A complete URL.
+`meta` | Hash | No | meta can contain the `title` object.
 
 #### Response
 


### PR DESCRIPTION
## Proposed changes

The url object documentation was missing explanation about how to set the title for web_content

## Types of changes

- [x] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

