### PR TITLE
Link title doesn't have to be wrapped in `meta` object for our API consumers

### DIFF
--- a/source/includes/_board-api.md
+++ b/source/includes/_board-api.md
@@ -70,7 +70,7 @@ curl https://dev.wetransfer.com/v2/boards/{board_id}/links \
   -H "x-api-key: your_api_key" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer jwt_token" \
-  -d '[{"url": "https://wetransfer.com/", "meta": {"title": "WeTransfer"}}]'
+  -d '[{"url": "https://wetransfer.com/", "title": "WeTransfer"}]'
 ```
 
 ```ruby
@@ -80,9 +80,7 @@ curl https://dev.wetransfer.com/v2/boards/{board_id}/links \
 ```javascript
 const linkItems = await apiClient.board.addLinks(board, [{
   url: 'https://wetransfer.com/',
-  meta: {
-    title: "WeTransfer"
-  }
+  title: "WeTransfer"
 }]);
 ```
 
@@ -101,25 +99,18 @@ const linkItems = await apiClient.board.addLinks(board, [{
 | `Authorization` | String | Yes      | Bearer JWT authorization token |
 | `Content-Type`  | String | Yes      | must be application/json       |
 
-#### Parameters
+#### Request Body
 
-| name    | type        | required | description                                  |
-| ------- | ----------- | -------- | -------------------------------------------- |
-| `links` | Array(Link) | Yes      | A list of links to send to an existing board |
+| type   | required | description                                                    |
+| ------ | -------- | -------------------------------------------------------------- |
+| Array  | Yes      | A list of link objects(see below) to send to an existing board |
 
-#### File object
+#### Link object
 
-| name   | type   | required | description                                |
-| ------ | ------ | -------- | ------------------------------------------ |
-| `url`  | String | Yes      | The complete URL of the link               |
-| `meta` | Hash   | Yes      | An object containing the metadata of the link |
-
-#### Meta
-
-| name   | type   | required | description                                |
-| ------ | ------ | -------- | ------------------------------------------ |
-| `title`  | String | Yes      | The title of the link. Can be custom.    |
-
+| name    | type   | required | description                                |
+| ------- | ------ | -------- | ------------------------------------------ |
+| `url`   | String | Yes      | The complete URL of the link               |
+| `title` | String | No       | The title of the page, defaults to the url |
 
 #### Response
 


### PR DESCRIPTION
## TL;DR

* a proposed change to v2
* Implementation: https://github.com/WeTransfer/blackbird-api/pull/22

---

After this change, if you add an URL to a board, the data you send just has 2 properties: The `url` ( a `string`) and the `title` (also a `string`). This reduces the complexity of sending the `title` inside a `meta` object.

We go from 

```javascript
 const linkItems = await apiClient.board.addLinks(board, [{
  url: 'https://wetransfer.com/',
  meta: {
    title: "WeTransfer"
  }
}]);
``` 

to 

```javascript
const linkItems = await apiClient.board.addLinks(board, [{
  url: 'https://wetransfer.com/',
  title: "WeTransfer"
}]);
```

## Types of changes

What types of changes does your code introduce to wt-api-docs?
_Put an `x` in the boxes that apply_

- [x] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] a breaking change - Please discuss wether the current form should be deprecated or removed. Removal has my preference since this PR is to v2-release ( #49 )

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I added the related changes in API. PR: https://github.com/WeTransfer/blackbird-api/pull/22 
- [x] Any dependent changes have been merged and published in downstream modules