### PR TITLE
Document Embed Translations

### DIFF
--- a/source/includes/_embed.md
+++ b/source/includes/_embed.md
@@ -81,7 +81,8 @@ This line creates an element that will display the file selector.
 <script type="text/props">
   {
     "wtEmbedKey": "0a2b5190-8914-442d-a877-cbd68d571101",
-    "wtEmbedOutput": ".wt_embed_output"
+    "wtEmbedOutput": ".wt_embed_output",
+    "wtEmbedLanguage: "en"
   }
 </script>
 ```
@@ -131,10 +132,10 @@ This is the input field for your form that holds the link to your transfer. It h
 
 To display Embed in a different language, simple change the `wtEmbedLanguage` parameter in the code snippet. Embed currently supports the following languages:
 
-| language | code |
-| -------- | ---- |
-| English  | `en` |
-| Dutch    | `nl` |
+| language          | code |
+| ----------------- | ---- |
+| English (default) | `en` |
+| Dutch             | `nl` |
 
 ## Examples
 

--- a/source/includes/_embed.md
+++ b/source/includes/_embed.md
@@ -70,7 +70,7 @@ With that setup, whenever a user fills out the form; a link to the uploaded mate
 Let's go over that code part by part, to see what it actually does.
 
 ```html
-<div data-widget-host="habitat" id="wt_embed"></div>
+<div data-widget-host="habitat" id="wt_embed">
 ```
 
 This line creates an element that will display the file selector.

--- a/source/includes/_embed.md
+++ b/source/includes/_embed.md
@@ -129,7 +129,7 @@ This is the input field for your form that holds the link to your transfer. It h
 
 ## Translations
 
-To display Embed in a different language, simple change the language parameter in the code snippet. Embed currently supports the following languages:
+To display Embed in a different language, simple change the `wtEmbedLanguage` parameter in the code snippet. Embed currently supports the following languages:
 
 | language | code |
 | -------- | ---- |

--- a/source/includes/_embed.md
+++ b/source/includes/_embed.md
@@ -70,7 +70,7 @@ With that setup, whenever a user fills out the form; a link to the uploaded mate
 Let's go over that code part by part, to see what it actually does.
 
 ```html
-<div data-widget-host="habitat" id="wt_embed">
+<div data-widget-host="habitat" id="wt_embed"></div>
 ```
 
 This line creates an element that will display the file selector.
@@ -126,6 +126,15 @@ Feel free to remove these lines from your code base. Or follow the advise and ma
 ```
 
 This is the input field for your form that holds the link to your transfer. It has a `name` attribute of `"wt_embed_output"`, meaning that it will be sent to your backend system, using that name. The `class` attribute is used (in this example) to connect embed to it.
+
+## Translations
+
+To display Embed in a different language, simple change the language parameter in the code snippet. Embed currently supports the following languages:
+
+| language | code |
+| -------- | ---- |
+| English  | `en` |
+| Dutch    | `nl` |
 
 ## Examples
 


### PR DESCRIPTION
## Proposed changes

Embed is adding support for translations in an upcoming release. This prepares the documentation for that. Currently it only displays two languages, English and Dutch, but this should be changed immediately when a new language is supported.

<!-- Make sure to fill out the issue id after the #-sign -->
Closes https://wetransfer.atlassian.net/browse/PUBAPI-145


Here's what the change  looks like in action (as of writing this PR)

![image](https://user-images.githubusercontent.com/306036/61216830-a15b3280-a70e-11e9-80b2-a505cd760f5e.png)


## Types of changes

What types of changes does your code introduce to wt-api-docs?
_Put an `x` in the boxes that apply_

- [X] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

