### PR TITLE
Adds Spanish to supported translations in Embed

### DIFF
--- a/source/includes/_embed.md
+++ b/source/includes/_embed.md
@@ -135,6 +135,7 @@ To display Embed in a different language, simple change the `wtEmbedLanguage` pa
 | language          | code |
 | ----------------- | ---- |
 | English (default) | `en` |
+| Spanish           | `es` |
 | Dutch             | `nl` |
 
 ## Examples


### PR DESCRIPTION
This add Spanish to the table of supported languages on the Embed documentation